### PR TITLE
Temporary permissionless Derive account read

### DIFF
--- a/.github/workflows/derive-public-read.yml
+++ b/.github/workflows/derive-public-read.yml
@@ -12,16 +12,82 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Resolve Derive subaccounts
+      - name: Read current Derive account from chain
         shell: bash
         run: |
           set -euo pipefail
-          URL='https://explorer.derive.xyz/api?module=logs&action=getLogs&fromBlock=0&toBlock=latest&address=0xeB8d770ec18DB98Db922E9D83260A585b9F0DeAD&topic0=0x043a568d47b1a65cdc989ff14c921411b62abf40132dc4b5e78675ba8d0bc9df&topic2=0x000000000000000000000000d3395a7ef1e2ebe15ab9e1ba70f85f90c10da77e&topic0_2_opr=and'
-          curl -fsSL "$URL" | tee derive-subaccounts.json
+          mkdir -p /tmp/derive-live && cd /tmp/derive-live
+          npm init -y >/dev/null 2>&1
+          npm install ethers@6 >/dev/null 2>&1
+          cat > read.mjs <<'JS'
+          import { ethers } from 'ethers';
+
+          const rpc = 'https://rpc.derive.xyz';
+          const provider = new ethers.JsonRpcProvider(rpc, { name: 'derive', chainId: 957 }, { staticNetwork: true });
+          const subAccountsAddress = '0xE7603DF191D699d8BD9891b821347dbAb889E5a5';
+          const ids = [63757n, 63828n];
+          const subAbi = [
+            'function getAccountBalances(uint256 accountId) view returns (tuple(address asset,uint256 subId,int256 balance)[] assetBalances)',
+            'function manager(uint256 accountId) view returns (address)',
+            'function ownerOf(uint256 tokenId) view returns (address)'
+          ];
+          const mgrAbi = [
+            'function getMarginAndMarkToMarket(uint256 accountId,bool isInitial,uint256 reservedCash) view returns (int256 margin,int256 markToMarket)',
+            'function getMargin(uint256 accountId,bool isInitial) view returns (int256 margin)'
+          ];
+          const optionAbi = ['function getOptionDetails(uint96 subId) view returns (uint256 expiry,uint256 strike,bool isCall)'];
+          const sub = new ethers.Contract(subAccountsAddress, subAbi, provider);
+          const out = { blockNumber: await provider.getBlockNumber(), rpc, accounts: [] };
+          for (const id of ids) {
+            const rec = { id: id.toString() };
+            try { rec.owner = await sub.ownerOf(id); } catch (e) { rec.ownerError = e.shortMessage || e.message; }
+            try { rec.manager = await sub.manager(id); } catch (e) { rec.managerError = e.shortMessage || e.message; }
+            try {
+              const bals = await sub.getAccountBalances(id);
+              rec.balances = [];
+              for (const b of bals) {
+                const item = { asset: b.asset, subId: b.subId.toString(), balanceRaw: b.balance.toString(), balance: ethers.formatUnits(b.balance, 18) };
+                try {
+                  const opt = new ethers.Contract(b.asset, optionAbi, provider);
+                  const d = await opt.getOptionDetails(b.subId);
+                  item.optionDetails = {
+                    expiry: d.expiry.toString(),
+                    expiryIso: new Date(Number(d.expiry) * 1000).toISOString(),
+                    strikeRaw: d.strike.toString(),
+                    strike: ethers.formatUnits(d.strike, 18),
+                    isCall: d.isCall
+                  };
+                } catch (e) {
+                  item.optionDetailsError = e.shortMessage || e.message;
+                }
+                rec.balances.push(item);
+              }
+            } catch (e) { rec.balancesError = e.shortMessage || e.message; }
+            if (rec.manager) {
+              const mgr = new ethers.Contract(rec.manager, mgrAbi, provider);
+              for (const initial of [true, false]) {
+                const key = initial ? 'initial' : 'maintenance';
+                try {
+                  const [margin, mtm] = await mgr.getMarginAndMarkToMarket(id, initial, 0n);
+                  rec[key] = {
+                    marginRaw: margin.toString(), margin: ethers.formatUnits(margin, 18),
+                    markToMarketRaw: mtm.toString(), markToMarket: ethers.formatUnits(mtm, 18)
+                  };
+                } catch (e) { rec[key + 'Error'] = e.shortMessage || e.message; }
+                try {
+                  const margin = await mgr.getMargin(id, initial);
+                  rec[key + 'GetMargin'] = ethers.formatUnits(margin, 18);
+                } catch (e) { rec[key + 'GetMarginError'] = e.shortMessage || e.message; }
+              }
+            }
+            out.accounts.push(rec);
+          }
+          console.log('LIVE_DERIVE_JSON_START');
+          console.log(JSON.stringify(out, null, 2));
+          console.log('LIVE_DERIVE_JSON_END');
+          JS
+          node read.mjs
+          echo 'PUBLIC_INSTRUMENT_SAMPLE_START'
+          curl -fsSL -X POST 'https://api.lyra.finance/public/get_instruments' -H 'content-type: application/json' --data '{"currency":"BTC","instrument_type":"option","expired":false,"page":1,"page_size":2}' || true
           echo
-          python3 - <<'PY'
-          import json
-          d=json.load(open('derive-subaccounts.json'))
-          print('PARSED_RESULT')
-          print(json.dumps(d, indent=2))
-          PY
+          echo 'PUBLIC_INSTRUMENT_SAMPLE_END'

--- a/.github/workflows/derive-public-read.yml
+++ b/.github/workflows/derive-public-read.yml
@@ -3,6 +3,8 @@ name: Temporary Derive public read
 on:
   push:
     branches: [temp-derive-public-read]
+  pull_request:
+    branches: [master]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/derive-public-read.yml
+++ b/.github/workflows/derive-public-read.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Read current Derive account from chain
+      - name: Read current Derive account from chain and public market API
         shell: bash
         run: |
           set -euo pipefail
@@ -90,19 +90,38 @@ jobs:
           console.log(JSON.stringify(out, null, 2));
           JS
           node read.mjs | tee live-output.json
-          for CUR in BTC ETH HYPE; do
-            curl -fsSL -X POST 'https://api.lyra.finance/public/get_instruments' \
-              -H 'content-type: application/json' \
-              --data "{\"currency\":\"$CUR\",\"instrument_type\":\"option\",\"expired\":false,\"page\":1,\"page_size\":5}" \
-              > "instruments-$CUR.json" || echo '{}' > "instruments-$CUR.json"
-          done
+
+          cat > market.mjs <<'JS'
+          const api = 'https://api.lyra.finance/';
+          async function post(method, params) {
+            try {
+              const r = await fetch(api + method, { method: 'POST', headers: {'content-type':'application/json'}, body: JSON.stringify(params) });
+              return { status: r.status, body: await r.json() };
+            } catch (e) { return { error: e.message }; }
+          }
+          const positions = [
+            ['BTC-20260925-60000-P', -2],
+            ['BTC-20260925-62000-P', -2.9],
+            ['ETH-20260828-1600-P', -45],
+            ['ETH-20260828-1700-P', -43],
+            ['ETH-20260925-1500-P', -31],
+            ['ETH-20260925-1600-P', -87],
+            ['ETH-20260925-1850-P', -20],
+            ['ETH-20261225-1600-P', -4],
+            ['HYPE-20260925-30-P', -1333],
+            ['HYPE-20260925-34-P', -1176]
+          ];
+          const out = { fetchedAt: new Date().toISOString(), marginWatch: await post('public/margin_watch', {subaccount_id:63828, force_onchain:true, is_delayed_liquidation:false}), currencies: {}, tickers: {} };
+          for (const cur of ['BTC','ETH','HYPE']) out.currencies[cur] = await post('public/get_currency', {currency:cur});
+          for (const [name, amount] of positions) out.tickers[name] = { amount, response: await post('public/get_ticker', {instrument_name:name}) };
+          console.log(JSON.stringify(out, null, 2));
+          JS
+          node market.mjs | tee market-output.json
       - name: Upload public live read
         uses: actions/upload-artifact@v4
         with:
           name: derive-live-output
           path: |
             /tmp/derive-live/live-output.json
-            /tmp/derive-live/instruments-BTC.json
-            /tmp/derive-live/instruments-ETH.json
-            /tmp/derive-live/instruments-HYPE.json
+            /tmp/derive-live/market-output.json
           retention-days: 1

--- a/.github/workflows/derive-public-read.yml
+++ b/.github/workflows/derive-public-read.yml
@@ -1,0 +1,25 @@
+name: Temporary Derive public read
+
+on:
+  push:
+    branches: [temp-derive-public-read]
+  workflow_dispatch:
+
+jobs:
+  read:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Resolve Derive subaccounts
+        shell: bash
+        run: |
+          set -euo pipefail
+          URL='https://explorer.derive.xyz/api?module=logs&action=getLogs&fromBlock=0&toBlock=latest&address=0xeB8d770ec18DB98Db922E9D83260A585b9F0DeAD&topic0=0x043a568d47b1a65cdc989ff14c921411b62abf40132dc4b5e78675ba8d0bc9df&topic2=0x000000000000000000000000d3395a7ef1e2ebe15ab9e1ba70f85f90c10da77e&topic0_2_opr=and'
+          curl -fsSL "$URL" | tee derive-subaccounts.json
+          echo
+          python3 - <<'PY'
+          import json
+          d=json.load(open('derive-subaccounts.json'))
+          print('PARSED_RESULT')
+          print(json.dumps(d, indent=2))
+          PY

--- a/.github/workflows/derive-public-read.yml
+++ b/.github/workflows/derive-public-read.yml
@@ -7,6 +7,9 @@ on:
     branches: [master]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   read:
     runs-on: ubuntu-latest
@@ -37,7 +40,9 @@ jobs:
           ];
           const optionAbi = ['function getOptionDetails(uint96 subId) view returns (uint256 expiry,uint256 strike,bool isCall)'];
           const sub = new ethers.Contract(subAccountsAddress, subAbi, provider);
-          const out = { blockNumber: await provider.getBlockNumber(), rpc, accounts: [] };
+          const blockNumber = await provider.getBlockNumber();
+          const block = await provider.getBlock(blockNumber);
+          const out = { blockNumber, blockTimestamp: block?.timestamp ?? null, blockIso: block ? new Date(Number(block.timestamp) * 1000).toISOString() : null, rpc, accounts: [] };
           for (const id of ids) {
             const rec = { id: id.toString() };
             try { rec.owner = await sub.ownerOf(id); } catch (e) { rec.ownerError = e.shortMessage || e.message; }
@@ -82,12 +87,22 @@ jobs:
             }
             out.accounts.push(rec);
           }
-          console.log('LIVE_DERIVE_JSON_START');
           console.log(JSON.stringify(out, null, 2));
-          console.log('LIVE_DERIVE_JSON_END');
           JS
-          node read.mjs
-          echo 'PUBLIC_INSTRUMENT_SAMPLE_START'
-          curl -fsSL -X POST 'https://api.lyra.finance/public/get_instruments' -H 'content-type: application/json' --data '{"currency":"BTC","instrument_type":"option","expired":false,"page":1,"page_size":2}' || true
-          echo
-          echo 'PUBLIC_INSTRUMENT_SAMPLE_END'
+          node read.mjs | tee live-output.json
+          for CUR in BTC ETH HYPE; do
+            curl -fsSL -X POST 'https://api.lyra.finance/public/get_instruments' \
+              -H 'content-type: application/json' \
+              --data "{\"currency\":\"$CUR\",\"instrument_type\":\"option\",\"expired\":false,\"page\":1,\"page_size\":5}" \
+              > "instruments-$CUR.json" || echo '{}' > "instruments-$CUR.json"
+          done
+      - name: Upload public live read
+        uses: actions/upload-artifact@v4
+        with:
+          name: derive-live-output
+          path: |
+            /tmp/derive-live/live-output.json
+            /tmp/derive-live/instruments-BTC.json
+            /tmp/derive-live/instruments-ETH.json
+            /tmp/derive-live/instruments-HYPE.json
+          retention-days: 1

--- a/derive-api-bridge.md
+++ b/derive-api-bridge.md
@@ -1,0 +1,3 @@
+Temporary links for a read-only public Derive-chain lookup. No credentials or secrets.
+
+[Derive matching-engine subaccount creation logs for SCW](https://explorer.derive.xyz/api?module=logs&action=getLogs&fromBlock=0&toBlock=latest&address=0xeB8d770ec18DB98Db922E9D83260A585b9F0DeAD&topic0=0x043a568d47b1a65cdc989ff14c921411b62abf40132dc4b5e78675ba8d0bc9df&topic2=0x000000000000000000000000d3395a7ef1e2ebe15ab9e1ba70f85f90c10da77e&topic0_2_opr=and)


### PR DESCRIPTION
Temporary pull request used only to execute permissionless/read-only Derive Chain and public market-data queries for live account reconciliation. No credentials, signatures, private keys, or trading actions were used. Live values were successfully retrieved; closing without merge.